### PR TITLE
Update purenail mods

### DIFF
--- a/ModLinks.xml
+++ b/ModLinks.xml
@@ -4336,9 +4336,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>DarknessRandomizer</Name>
         <Description>A Rando 4 connection to randomize the dark corners of Hallownest.</Description>
-        <Version>1.4.5.0</Version>
-        <Link SHA256="5773892F72D7CE223D26CE72BFB6E9E77375D3212255A0F22C50AB8E57245CC5">
-            <![CDATA[https://github.com/dplochcoder/HollowKnight.DarknessRandomizer/releases/download/v1.4.5.0/DarknessRandomizer.zip]]>
+        <Version>1.4.6.0</Version>
+        <Link SHA256="BA152798A652723EF7053A93969218D75F65CB41916E2E940B8E7078E029486C">
+            <![CDATA[https://github.com/dplochcoder/HollowKnight.DarknessRandomizer/releases/download/v1.4.6.0/DarknessRandomizer.zip]]>
         </Link>
         <Dependencies>
             <Dependency>ItemChanger</Dependency>
@@ -4361,9 +4361,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>MoreDoors</Name>
         <Description>A Rando 4 connection which adds more locked doors to Hallownest.</Description>
-        <Version>2.0.6.0</Version>
-        <Link SHA256="3337E34C9DE8A48235FD8B5D318A2144F45839672BBC2E03360EF25B488D7D92">
-            <![CDATA[https://github.com/dplochcoder/HollowKnight.MoreDoors/releases/download/v2.0.6.0/MoreDoors.zip]]>
+        <Version>2.0.7.0</Version>
+        <Link SHA256="6557EA0573F5FD1D862FC4103000C5193C9DA0AE3F7506A7359B39F98EF859CF">
+            <![CDATA[https://github.com/dplochcoder/HollowKnight.MoreDoors/releases/download/v2.0.7.0/MoreDoors.zip]]>
         </Link>
         <Dependencies>
             <Dependency>ItemChanger</Dependency>
@@ -4386,9 +4386,9 @@ This is a singleplayer mod. The "teamwork" refers to in-game events.</Descriptio
     <Manifest>
         <Name>PurenailCore</Name>
         <Description>Common utilities and interop for Purenail mods</Description>
-        <Version>1.1.6.0</Version>
-        <Link SHA256="B92B2A7F2FAACF142AEEB97F717C00185AA068E65D8102CC9C6D7253B2043BFF">
-            <![CDATA[https://github.com/dplochcoder/HollowKnight.PurenailCore/releases/download/v1.1.6.0/PurenailCore.zip]]>
+        <Version>1.1.7.0</Version>
+        <Link SHA256="2C44C842B51F55F4BA85D145DC72D9B731CE74E12084BF0A92BED7A4F10C4D1D">
+            <![CDATA[https://github.com/dplochcoder/HollowKnight.PurenailCore/releases/download/v1.1.7.0/PurenailCore.zip]]>
         </Link>
         <Dependencies>
             <Dependency>Randomizer 4</Dependency>


### PR DESCRIPTION
 - Adds a new `[PrefabPreload]` feature to PurenailCore, using the updated modding api
 - Fixes a bug with DarknessRando + MoreDoors logic interop that triggered if both were installed, but only DarknessRando was enabled